### PR TITLE
Docker copy link

### DIFF
--- a/docker/act-runner-environment/Dockerfile
+++ b/docker/act-runner-environment/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.4
+
 # A Debian based minimal Node.js environment with Python installed; mostly used for running the GitHub Action CI
 # locally via "act"; tries to mimic the runtime environment of GitHub Actions while being as minimal as possible
 FROM node:slim@sha256:3894373926629c8e2c437314fb253b5d261efa6bddb2c947474406470fee2890

--- a/docker/caddy/Dockerfile
+++ b/docker/caddy/Dockerfile
@@ -8,7 +8,7 @@ RUN xcaddy build \
 
 FROM caddy:alpine@sha256:f95672886ddd6284ccba4b0be903d0d0949d7c665f5e7acc96cc6a0af2467364
 
-COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+COPY --from=builder --link=true /usr/bin/caddy /usr/bin/caddy
 
 # Allow to run Caddy on privileged ports (as a non-root user)
 RUN apk --update-cache --no-cache add libcap=~2.50 && \

--- a/docker/home-assistant/Dockerfile
+++ b/docker/home-assistant/Dockerfile
@@ -15,6 +15,6 @@ ENV HOME_ASSISTANT_ENTRYPOINT="/etc/services.d/home-assistant/run"
 # runtime (which is obviously not desirable)
 RUN cat ${HOME_ASSISTANT_ENTRYPOINT} > /dev/null
 # copy/override the entry point of home-assistant
-COPY --from=build /tmp/homeassistant-docker-venv/run ${HOME_ASSISTANT_ENTRYPOINT}
+COPY --from=build --link=true /tmp/homeassistant-docker-venv/run ${HOME_ASSISTANT_ENTRYPOINT}
 # update linux base packages (to fix potential security issues)
 RUN apk update --no-cache && apk upgrade --no-cache

--- a/docker/home-assistant/Dockerfile
+++ b/docker/home-assistant/Dockerfile
@@ -1,11 +1,11 @@
-# a HomeAssistant version that can be run as non-root user
-
+# syntax=docker/dockerfile:1.4
 FROM alpine/git:v2.32.0@sha256:a8a31155488a93a4d8abb834777c7b5f9d7c93db6051defbad8cc066b4e90072 as build
 
 ENV GIT_TAG_VERSION="v2.3"
 WORKDIR /tmp/homeassistant-docker-venv
 RUN git clone --depth 1 --branch ${GIT_TAG_VERSION} https://github.com/tribut/homeassistant-docker-venv.git .
 
+# a HomeAssistant version that can be run as non-root user
 FROM homeassistant/home-assistant:2022.3@sha256:ba21b80e476575feb2195797e31e968bb36f4b9c4c77040b1f761e3e6f7a903a
 
 ENV HOME_ASSISTANT_ENTRYPOINT="/etc/services.d/home-assistant/run"


### PR DESCRIPTION
Use the new `--link=true` flag on Docker `copy` statements:
https://www.docker.com/blog/image-rebase-and-improved-remote-cache-support-in-new-buildkit/